### PR TITLE
Implement --target-attribute-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ Usage: nixtract [OPTIONS] OUTFILE
   stdout.
 
 Options:
-  --target-flake-ref TEXT  The reference of the target Nix Flake
-  --target-system TEXT     The system in which to evaluate the derivations
-  --n-workers INTEGER      Count of workers to spawn to describe the stream of
-                           found derivations
-  --offline                Pass --offline to Nix commands
-  -v, --verbose            Increase verbosity
-  --help                   Show this message and exit.
+  --target-flake-ref TEXT       The reference of the target Nix Flake
+  --target-attribute-path TEXT  The attribute path of the provided
+                                attribute set to evaluate. If empty, the
+                                entire attribute set is evaluated
+  --target-system TEXT          The system in which to evaluate the
+                                derivations
+  --n-workers INTEGER           Count of workers to spawn to describe the
+                                stream of found derivations
+  --offline                     Pass --offline to Nix commands
+  -v, --verbose                 Increase verbosity
+  --help                        Show this message and exit.
 ```
 
 ### Extract nixpkgs graph of derivations
@@ -63,6 +67,12 @@ in order to extract from a specific flake, use `--target-flake-ref`:
 
 ```console
 $ nixtract --target-flake-ref 'github:nixos/nixpkgs/23.05' -
+```
+
+in order to extract from a specific attribute, use `--target-attribute`:
+
+```console
+$ nixtract --target-attribute-path 'haskellPackages.hello' -
 ```
 
 in order to extract for a specific system, use `--target-system`:

--- a/nixtract/cli.py
+++ b/nixtract/cli.py
@@ -246,6 +246,11 @@ def queue_processor(
     help="The reference of the target Nix Flake",
 )
 @click.option(
+    "--target-attribute-path",
+    default="",
+    help="The attribute path of the provided attribute set to evaluate",
+)
+@click.option(
     "--target-system",
     default="x86_64-linux",
     help="The system in which to evaluate the derivations",
@@ -270,6 +275,7 @@ def queue_processor(
 def cli(
     outfile: IO[str],
     target_flake_ref: str,
+    target_attribute_path: str,
     target_system: str,
     n_workers: int,
     offline: bool,
@@ -293,6 +299,7 @@ def cli(
         # arguments to the Nix expression can't be passed with `nix eval`
         # we use environment variables instead
         "TARGET_FLAKE_REF": str(target_flake_ref),
+        "TARGET_ATTRIBUTE_PATH": str(target_attribute_path),
         "TARGET_SYSTEM": str(target_system),
     }
     logger.info(


### PR DESCRIPTION
This PR adds the `--target-attribute-path` to the cli, allowing the extraction of a predetermined attribute path.