### PR TITLE
Output the description field of the nixpkgs metadata

### DIFF
--- a/nixtract/describe-derivation.nix
+++ b/nixtract/describe-derivation.nix
@@ -30,10 +30,11 @@ in
   attributePath = targetAttributePath;
   nixpkgsMetadata =
     {
-      pname = (builtins.tryEval (if targetValue ? pname then targetValue.pname else false)).value or null;
-      version = (builtins.tryEval (if targetValue ? version then targetValue.version else "")).value;
-      broken = (builtins.tryEval (if targetValue ? meta.broken then targetValue.meta.broken else false)).value;
-      license = (builtins.tryEval (if targetValue ? meta.license.fullName then targetValue.meta.license.fullName else "")).value;
+      description = (builtins.tryEval (targetValue.meta.description or "")).value;
+      pname = (builtins.tryEval (targetValue.pname or false)).value or null;
+      version = (builtins.tryEval (targetValue.version or "")).value;
+      broken = (builtins.tryEval (targetValue.meta.broken or false)).value;
+      license = (builtins.tryEval (targetValue.meta.license.fullName or "")).value;
     };
 
   # path to the evaluated derivation file

--- a/nixtract/model.py
+++ b/nixtract/model.py
@@ -11,6 +11,10 @@ def snake_case_to_camel_case(name: str):
 class NixpkgsMetadata(BaseModel):
     """Derivation metadata defined by nixpkgs specifically."""
 
+    description: str | None = Field(
+        default=None,
+        description="The description of the Nix derivation",
+    )
     pname: str | None = Field(
         default=None,
         description="The pname attribute of the Nix derivation",


### PR DESCRIPTION
This PR also uses the `or` keyword over manually checking if a path exists.