### PR TITLE
Update package name to nixtract-cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "nixtract"
+name = "nixtract-cli"
 version = "0.1.0"
 description = "A CLI tool to extract the graph of derivations from a Nix flake."
 authors = [


### PR DESCRIPTION
The name `nixtract` is unfortunately already taken on PyPI [by an unrelated project](https://pypi.org/project/nixtract/). This PR updates the package name in our pyproject.toml to `nixtract-cli` which is currently still available.