### PR TITLE
Update docs to reference PyPI project 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ nix shell github:tweag/nixtract
 or install in your Python environment:
 
 ```console
-$ pip install git+https://github.com/tweag/nixtract.git
+$ pip install nixtract-cli
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://img.shields.io/github/actions/workflow/status/tweag/nixtract/ci.yml
+[![PyPI Latest Release](https://img.shields.io/pypi/v/nixtract-cli.svg)](https://pypi.org/project/nixtract-cli/) ![Build](https://img.shields.io/github/actions/workflow/status/tweag/nixtract/ci.yml
 ) [![Discord channel](https://img.shields.io/discord/1174731094726295632)](https://discord.gg/53XwX7Ft)
 
 # `nixtract`


### PR DESCRIPTION
Updated the README to include references to the new PyPI project and updated the `pip install` instructions to point to it rather than GitHub.