### PR TITLE
Parse and output entire license list if present

### DIFF
--- a/nixtract/describe-derivation.nix
+++ b/nixtract/describe-derivation.nix
@@ -35,7 +35,7 @@ in
       version = (builtins.tryEval (targetValue.version or "")).value;
       broken = (builtins.tryEval (targetValue.meta.broken or false)).value;
       homepage = (builtins.tryEval (targetValue.meta.homepage or "")).value;
-      license = (builtins.tryEval (
+      licenses = (builtins.tryEval (
         if builtins.isAttrs (targetValue.meta.license or null)
         # In case the license attribute is not a list, we produce a singleton list to be consistent
         then [{

--- a/nixtract/describe-derivation.nix
+++ b/nixtract/describe-derivation.nix
@@ -35,7 +35,24 @@ in
       version = (builtins.tryEval (targetValue.version or "")).value;
       broken = (builtins.tryEval (targetValue.meta.broken or false)).value;
       homepage = (builtins.tryEval (targetValue.meta.homepage or "")).value;
-      license = (builtins.tryEval (targetValue.meta.license.fullName or "")).value;
+      license = (builtins.tryEval (
+        if builtins.isAttrs (targetValue.meta.license or null)
+        # In case the license attribute is not a list, we produce a singleton list to be consistent
+        then [{
+          spdxId = targetValue.meta.license.spdxId or "";
+          fullName = targetValue.meta.license.fullName or "";
+        }]
+        # In case the license attribute is a list
+        else if builtins.isList (targetValue.meta.license or null)
+        then
+          builtins.map
+            (l: {
+              spdxId = l.spdxId or "";
+              fullName = l.fullName or "";
+            })
+            targetValue.meta.license
+        else null
+      )).value;
     };
 
   # path to the evaluated derivation file

--- a/nixtract/model.py
+++ b/nixtract/model.py
@@ -8,6 +8,21 @@ def snake_case_to_camel_case(name: str):
     return "".join([parts[0]] + [part.capitalize() for part in parts[1:]])
 
 
+class License(BaseModel):
+    """The license(s) of a Nix derivation"""
+
+    spdx_id: str | None = Field(
+        description="The SPDX Id of the license",
+    )
+    full_name: str | None = Field(
+        description="The descriptive full name of the license",
+    )
+
+    class Config:
+        alias_generator = snake_case_to_camel_case
+        allow_population_by_field_name = True
+
+
 class NixpkgsMetadata(BaseModel):
     """Derivation metadata defined by nixpkgs specifically."""
 
@@ -31,9 +46,9 @@ class NixpkgsMetadata(BaseModel):
         default=None,
         description="The derivation's homepage",
     )
-    license: str | None = Field(
+    licenses: list[License] | None = Field(
         default=None,
-        description="The derivation's license",
+        description="The derivation's license(s)",
     )
 
 

--- a/tests/fixtures/flake-direct-buildInput/flake.nix
+++ b/tests/fixtures/flake-direct-buildInput/flake.nix
@@ -15,6 +15,7 @@
             mkdir -p $out/bin
             cp $src/* $out/bin
           '';
+          meta.license = pkgs.lib.licenses.gpl2Plus;
         };
 
         pkg2 = pkgs.stdenv.mkDerivation {
@@ -28,6 +29,7 @@
             mkdir -p $out/bin
             cp $src/* $out/bin
           '';
+          meta.license = with pkgs.lib; [ licenses.mit licenses.asl20 ];
         };
 
       in

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,6 +117,13 @@ def test_direct_buildinput():
     assert pkg2_node.get("output_path") is not None
     assert pkg2_node.get("name") == "pkg2"
     assert pkg2_node.get("parsed_name", {}).get("name") == "pkg2"
+    assert (
+        pkg2_node.get("nixpkgs_metadata", {}).get("licenses")[0].get("spdx_id") == "MIT"
+    )
+    assert (
+        pkg2_node.get("nixpkgs_metadata", {}).get("licenses")[1].get("spdx_id")
+        == "Apache-2.0"
+    )
     assert len(pkg2_node.get("build_inputs")) >= 1
     pkg2_buildinput_pkg1 = next(
         (
@@ -133,6 +140,10 @@ def test_direct_buildinput():
     assert pkg1_node is not None
     assert pkg1_node.get("output_path") == pkg2_buildinput_pkg1["output_path"]
     assert pkg1_node.get("output_path") == pkg2_buildinput_pkg1["output_path"]
+    assert (
+        pkg1_node.get("nixpkgs_metadata", {}).get("licenses")[0].get("spdx_id")
+        == "GPL-2.0-or-later"
+    )
 
     # test behavior through logs
     # quite unstable, will do for now


### PR DESCRIPTION
This also changes the full license name to the `spdxId` instead, which I argue is better suited for the purpose anyway.