### PR TITLE
Output the homepage of a derivation if present

### DIFF
--- a/nixtract/describe-derivation.nix
+++ b/nixtract/describe-derivation.nix
@@ -34,6 +34,7 @@ in
       pname = (builtins.tryEval (targetValue.pname or false)).value or null;
       version = (builtins.tryEval (targetValue.version or "")).value;
       broken = (builtins.tryEval (targetValue.meta.broken or false)).value;
+      homepage = (builtins.tryEval (targetValue.meta.homepage or "")).value;
       license = (builtins.tryEval (targetValue.meta.license.fullName or "")).value;
     };
 

--- a/nixtract/model.py
+++ b/nixtract/model.py
@@ -27,6 +27,10 @@ class NixpkgsMetadata(BaseModel):
         default=None,
         description="Flag indicating whether the derivation is broken",
     )
+    homepage: str | None = Field(
+        default=None,
+        description="The derivation's homepage",
+    )
     license: str | None = Field(
         default=None,
         description="The derivation's license",


### PR DESCRIPTION
Will be used in Genealogos to populate part of the the `external_references`.