### PR TITLE
Include git source and revision to the output

### DIFF
--- a/nixtract/describe-derivation.nix
+++ b/nixtract/describe-derivation.nix
@@ -28,6 +28,17 @@ in
   name = targetValue.name;
   parsedName = (builtins.parseDrvName targetValue.name);
   attributePath = targetAttributePath;
+
+  src =
+    if targetValue ? src.gitRepoUrl && targetValue ? src.rev
+    then
+      {
+        gitRepoUrl = targetValue.src.gitRepoUrl or null;
+        rev = targetValue.src.rev or null;
+      }
+    else
+      null;
+
   nixpkgsMetadata =
     {
       description = (builtins.tryEval (targetValue.meta.description or "")).value;

--- a/nixtract/model.py
+++ b/nixtract/model.py
@@ -8,6 +8,24 @@ def snake_case_to_camel_case(name: str):
     return "".join([parts[0]] + [part.capitalize() for part in parts[1:]])
 
 
+class Source(BaseModel):
+    """The source or `src` attribute of the derivation."""
+
+    git_repo_url: str | None = Field(
+        default=None,
+        description="The .git url of the source",
+    )
+    rev: str | None = Field(
+        default=None,
+        description="The revision of the url if relevant",
+    )
+
+    class Config:
+        use_enum_values = True
+        alias_generator = snake_case_to_camel_case
+        allow_population_by_field_name = True
+
+
 class License(BaseModel):
     """The license(s) of a Nix derivation"""
 
@@ -129,6 +147,10 @@ class Derivation(BaseModel):
     nixpkgs_metadata: NixpkgsMetadata | None = Field(
         default=None,
         description="Optional metadata specific to derivations from nixpkgs",
+    )
+    src: Source | None = Field(
+        default=None,
+        description="Source of the derivation",
     )
     build_inputs: list[BuildInput] = Field(
         description="The derivation's build inputs",

--- a/tests/fixtures/flake-trivial-rust/flake.lock
+++ b/tests/fixtures/flake-trivial-rust/flake.lock
@@ -1,0 +1,74 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hello": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-xe8Hie69L308iLb9d7X5Kbvqm4z4X8PT4oW/TOZPwAM=",
+        "type": "file",
+        "url": "https://git.savannah.gnu.org/git/hello.git"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://git.savannah.gnu.org/git/hello.git"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1684580438,
+        "narHash": "sha256-LUPswmDn6fXP3lEBJFA2Id8PkcYDgzUilevWackYVvQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7dc71aef32e8faf065cb171700792cf8a65c152d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "hello": "hello",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/flake-trivial-rust/flake.nix
+++ b/tests/fixtures/flake-trivial-rust/flake.nix
@@ -1,0 +1,36 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.hello = {
+    url = "https://git.savannah.gnu.org/git/hello.git";
+    flake = false;
+  };
+
+  outputs = { flake-utils, nixpkgs, hello, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "hello";
+          version = "0.1.0";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "hello-lang";
+            repo = "Rust";
+            rev = "8e8bd39a444f6d6c7b01046a6b0600273911ac58";
+            hash = "sha256-w3IRfqPsLFAY7OpLRaJpnIUIMhtJ71xi1PJGNttb9EQ=";
+          };
+
+          cargoHash = "sha256-eouoalg2VO6SCG9oaCPqmlfWnKI+uy6ggPX7IKG1hz4=";
+
+          meta = with pkgs.lib; {
+            description = "Hello World! in Rust";
+            homepage = "https://github.com/hello-lang/Rust";
+            license = licenses.unlicense;
+            maintainers = [ ];
+          };
+
+        };
+      }
+    );
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,3 +154,71 @@ def test_direct_buildinput():
     assert "READER THREAD EXIT" in cli_stderr
     assert "PROCESS QUEUE THREAD EXIT" in cli_stderr
     assert "POOL EXIT" in cli_stderr
+
+
+def test_trivial_trivial_rust():
+    import nixtract.cli
+    from nixtract.cli import cli
+
+    # need absolute path
+    flake_path = (Path(__file__).parent / "fixtures" / "flake-trivial-rust").absolute()
+    # sanity checks
+    assert flake_path.exists()
+    assert flake_path.is_dir()
+    assert (flake_path / "flake.nix").exists()
+    assert (flake_path / "flake.lock").exists()
+
+    # CLI logger
+    cli_stderr_handler = StringIO()
+    logging.getLogger(nixtract.cli.__name__).addHandler(
+        logging.StreamHandler(stream=cli_stderr_handler)
+    )
+
+    # test CLI
+    runner = CliRunner(
+        mix_stderr=False,
+    )
+    result = runner.invoke(
+        cli=cli,
+        args=[
+            "--target-flake-ref",
+            f"path:{flake_path}",
+            "--target-system",
+            "x86_64-linux",
+            "--verbose",
+            # print to stdout
+            "-",
+        ],
+    )
+
+    # test success
+    assert result.exit_code == 0
+
+    # test output node
+    assert result.stdout != "", "Empty result"
+    stdout_lines = result.stdout.splitlines()
+    result_nodes = [json.loads(line) for line in stdout_lines]
+    hello_node = next(
+        (node for node in result_nodes if node["name"] == "hello-0.1.0"), None
+    )
+    assert hello_node is not None
+    assert hello_node.get("output_path") is not None
+    assert hello_node.get("parsed_name", {}).get("name") == "hello"
+    assert (
+        hello_node.get("src", {}).get("git_repo_url", "")
+        == "https://github.com/hello-lang/Rust.git"
+    )
+    assert (
+        hello_node.get("src", {}).get("rev", "")
+        == "8e8bd39a444f6d6c7b01046a6b0600273911ac58"
+    )
+
+    # test behavior through logs
+    # quite unstable, will do for now
+    cli_stderr_handler.seek(0)
+    cli_stderr = cli_stderr_handler.read()
+    assert "FINDER EXIT" in cli_stderr
+    assert "QUEUE PROCESSOR CLOSED" in cli_stderr
+    assert "READER THREAD EXIT" in cli_stderr
+    assert "PROCESS QUEUE THREAD EXIT" in cli_stderr
+    assert "POOL EXIT" in cli_stderr


### PR DESCRIPTION
`Genealogos` can use this information to provide vcs information in the component purls.

Before: `"purl": "pkg:generic/openrgb@0.9"`
After: `"purl": "pkg:generic/openrgb?vcs_url=git+https://gitlab.com/CalcProgrammer1/OpenRGB.git@release_0.9"`