### PR TITLE
Change description output to snake_case

### DIFF
--- a/src/nix/describe_derivation.nix
+++ b/src/nix/describe_derivation.nix
@@ -26,9 +26,9 @@ let
 in
 {
   name = targetValue.name;
-  parsedName = (builtins.parseDrvName targetValue.name);
-  attributePath = targetAttributePath;
-  nixpkgsMetadata =
+  parsed_name = (builtins.parseDrvName targetValue.name);
+  attribute_path = targetAttributePath;
+  nixpkgs_metadata =
     {
       description = (builtins.tryEval (targetValue.meta.description or "")).value;
       pname = (builtins.tryEval (targetValue.pname or "")).value or null;
@@ -39,16 +39,16 @@ in
         if builtins.isAttrs (targetValue.meta.license or null)
         # In case the license attribute is not a list, we produce a singleton list to be consistent
         then [{
-          spdxId = targetValue.meta.license.spdxId or null;
-          fullName = targetValue.meta.license.fullName or null;
+          spdx_id = targetValue.meta.license.spdxId or null;
+          full_name = targetValue.meta.license.fullName or null;
         }]
         # In case the license attribute is a list
         else if builtins.isList (targetValue.meta.license or null)
         then
           builtins.map
             (l: {
-              spdxId = l.spdxId or null;
-              fullName = l.fullName or null;
+              spdx_id = l.spdxId or null;
+              full_name = l.fullName or null;
             })
             targetValue.meta.license
         else null
@@ -56,26 +56,26 @@ in
     };
 
   # path to the evaluated derivation file
-  derivationPath = lib.safePlatformDrvEval targetSystem (drv: drv.drvPath) targetValue;
+  derivation_Path = lib.safePlatformDrvEval targetSystem (drv: drv.drvPath) targetValue;
 
   # path to the realized (=built) derivation
   # note: we can't name it `outPath` because serialization would only output it instead of dict, see Nix `toString` docs
-  outputPath =
+  output_path =
     # TODO meaningfully represent when it's not the right platform (instead of null)
     lib.safePlatformDrvEval
       targetSystem
       (drv: drv.outPath)
       targetValue;
-  outputs = map (name: { inherit name; outputPath = lib.safePlatformDrvEval targetSystem (drv: drv.outPath) targetValue.${name}; }) (targetValue.outputs or [ ]);
-  buildInputs = nixpkgs.lib.lists.flatten
+  outputs = map (name: { inherit name; output_path = lib.safePlatformDrvEval targetSystem (drv: drv.outPath) targetValue.${name}; }) (targetValue.outputs or [ ]);
+  build_inputs = nixpkgs.lib.lists.flatten
     (map
       (inputType:
         map
           (elem:
             {
-              buildInputType = nixpkgs.lib.removeSuffix "s" (lib.toSnakeCase inputType);
-              attributePath = targetAttributePath + ".${inputType}.${builtins.toString elem.index}";
-              outputPath = lib.safePlatformDrvEval targetSystem (drv: drv.outPath) elem.value;
+              build_input_type = nixpkgs.lib.removeSuffix "s" (lib.toSnakeCase inputType);
+              attribute_path = targetAttributePath + ".${inputType}.${builtins.toString elem.index}";
+              output_path = lib.safePlatformDrvEval targetSystem (drv: drv.outPath) elem.value;
             }
           )
           (

--- a/src/nix/describe_derivation.rs
+++ b/src/nix/describe_derivation.rs
@@ -7,7 +7,6 @@ use super::lib::Lib;
 use crate::error::{Error, Result};
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all(deserialize = "camelCase"))]
 pub struct DerivationDescription {
     pub attribute_path: String,
     pub derivation_path: Option<String>,
@@ -21,21 +20,18 @@ pub struct DerivationDescription {
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all(deserialize = "camelCase"))]
 pub struct Output {
     pub name: String,
     pub output_path: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all(deserialize = "camelCase"))]
 pub struct ParsedName {
     pub name: String,
     pub version: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all(deserialize = "camelCase"))]
 pub struct NixpkgsMetadata {
     pub description: String,
     pub pname: String,
@@ -46,7 +42,6 @@ pub struct NixpkgsMetadata {
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all(deserialize = "camelCase"))]
 pub struct Source {
     pub git_repo_url: String,
     // Revision or tag of the git repo
@@ -54,7 +49,6 @@ pub struct Source {
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all(deserialize = "camelCase"))]
 pub struct License {
     // Not all licenses in nixpkgs have an associated spdx id
     pub spdx_id: Option<String>,
@@ -62,7 +56,6 @@ pub struct License {
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all(deserialize = "camelCase"))]
 pub struct BuiltInput {
     pub attribute_path: String,
     pub build_input_type: String,


### PR DESCRIPTION
This change is subtle.

Genealogos uses the internal nixtract structures to parse the nixtract traces. Previously, nixtract parsed lower camel case and outputed snake_case. This caused a discrepency in genealogos preventing is from parsing the nixtract output.

This PR changes the output of the `describe_derivation.nix` file to be `snake_case`. Thus making its output, and that of nixtract itself compatible.

In turn, this enables Genealogos to use the internal structures of nixtract to parse the output.

This is a braking change, since the internal structures (and their Serde traits) are part of the api.