### PR TITLE
Runtime only dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ## [Unreleased]
 ### Added
 - [#34](https://github.com/tweag/nixtract/pull/34) add option to provide nixtract with a status communication channel
+- [#36](https://github.com/tweag/nixtract/pull/36) add option to only extract runtime dependencies
 
 ### Fixed
 - [#38](https://github.com/tweag/nixtract/pull/38) fixed bug where found derivations were parsed incorrectly
+
+### Changed
+- [#36](https://github.com/tweag/nixtract/pull/36) moved all nixtract configuration options into a single struct passed to the `nixtract` function

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To extract the data from the `nixpkgs` of your flake registry and output to stdo
 $ nixtract
 ```
 
-you can specify a file path directly instead
+you can also specify an output file path directly instead
 
 ```console
 $ nixtract derivations.jsonl
@@ -98,16 +98,22 @@ in order to extract from a specific flake, use `--target-flake-ref` or `-f`:
 $ nixtract --target-flake-ref 'github:nixos/nixpkgs/23.05'
 ```
 
-in order to extract from a specific attribute, use `--target-attribute` or `-a`:
+in order to extract a specific attribute, use `--target-attribute` or `-a`:
 
 ```console
 $ nixtract --target-attribute-path 'haskellPackages.hello'
 ```
 
-in order to extract for a specific system, use `--target-system` or `-s`:
+in order to extract for a system different from your own, use `--target-system` or `-s`:
 
 ```console
 $ nixtract --target-system 'x86_64-darwin'
+```
+
+in order to only consider runtime dependencies, use `--runtime-only` or `-r`:
+
+```console
+$ nixtract --runtime-only
 ```
 
 ### Understanding the output

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,16 +85,7 @@ fn process(args: ProcessingArgs) -> Result<()> {
         },
     )?;
 
-    let description = nix::describe_derivation(
-        args.flake_ref,
-        args.system,
-        &args.attribute_path,
-        &args.offline,
-        &args.runtime_only,
-        &args.include_nar_info,
-        args.binary_caches,
-        args.lib,
-    )?;
+    let description = nix::describe_derivation(&nix::DescribeDerivationArgs::from(args.clone()))?;
 
     // Inform the calling thread that we have described the derivation
     send_message(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,10 @@
 //!     let attribute_path = Some("haskellPackages.hello");
 //!     let offline = false;
 //!     let include_nar_info = false;
+//!     let runtime_only = false;
 //!     let binary_caches = None;
 //!
-//!     let derivations = nixtract(flake_ref, system, attribute_path, offline, include_nar_info, binary_caches, None)?;
+//!     let derivations = nixtract(flake_ref, system, attribute_path, offline, include_nar_info, runtime_only, binary_caches, None)?;
 //!
 //!     for derivation in derivations {
 //!         println!("{:?}", derivation);
@@ -50,6 +51,7 @@ pub struct ProcessingArgs<'a> {
     pub attribute_path: String,
     pub offline: bool,
     pub include_nar_info: bool,
+    pub runtime_only: bool,
     pub binary_caches: &'a Vec<String>,
     pub lib: &'a nix::lib::Lib,
     pub tx: mpsc::Sender<DerivationDescription>,
@@ -88,6 +90,7 @@ fn process(args: ProcessingArgs) -> Result<()> {
         args.system,
         &args.attribute_path,
         &args.offline,
+        &args.runtime_only,
         &args.include_nar_info,
         args.binary_caches,
         args.lib,
@@ -165,6 +168,7 @@ pub fn nixtract(
     attribute_path: Option<impl Into<String>>,
     offline: bool,
     include_nar_info: bool,
+    runtime_only: bool,
     binary_caches: Option<Vec<String>>,
     message_tx: Option<mpsc::Sender<message::Message>>,
 ) -> Result<impl Iterator<Item = DerivationDescription>> {
@@ -215,6 +219,7 @@ pub fn nixtract(
                 system: &system,
                 attribute_path: found_drv.attribute_path,
                 offline,
+                runtime_only,
                 include_nar_info,
                 binary_caches: &binary_caches,
                 lib: &lib,

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,10 @@ struct Args {
     #[arg(long, default_value_t = false)]
     output_schema: bool,
 
+    /// Ouput only runtime dependencies
+    #[arg(long, short, default_value_t = false)]
+    runtime_only: bool,
+
     /// Write the output to a file instead of stdout or explicitly use `-` for stdout
     #[arg()]
     output_path: Option<String>,
@@ -188,6 +192,7 @@ fn main_with_args(
         opts.attribute_path,
         opts.offline,
         opts.include_nar_info,
+        opts.runtime_only,
         opts.binary_caches,
         Some(status_tx),
     )?;
@@ -242,6 +247,7 @@ mod tests {
                     // Write output to /dev/null to avoid cluttering the test output
                     output_path: Some("/dev/null".to_string()),
                     include_nar_info: false,
+                    runtime_only: false,
                     binary_caches: None,
                 };
 

--- a/src/nix/describe_derivation.rs
+++ b/src/nix/describe_derivation.rs
@@ -71,6 +71,7 @@ pub fn describe_derivation(
     system: &Option<String>,
     attribute_path: &String,
     offline: &bool,
+    runtime_only: &bool,
     include_nar_info: &bool,
     binary_caches: &[String],
     lib: &Lib,
@@ -88,6 +89,10 @@ pub fn describe_derivation(
             ("NIXPKGS_ALLOW_UNFREE".to_owned(), "1".to_owned()),
             ("NIXPKGS_ALLOW_INSECURE".to_owned(), "1".to_owned()),
             ("NIXPKGS_ALLOW_BROKEN".to_owned(), "1".to_owned()),
+            (
+                "RUNTIME_ONLY".to_owned(),
+                if *runtime_only { "1" } else { "0" }.to_owned(),
+            ),
         ]);
         if let Some(system) = system {
             res.insert("TARGET_SYSTEM".to_owned(), system.to_owned());


### PR DESCRIPTION
# Runtime only dependencies
Issue: #35 

## Description
This PR adds the -r and --runtime-only dependencies to nixtract and the `runtime_only: bool` argument to the `nixtract` function. Setting this value will make the resulting derivation descriptions only include `buildInputs` and `propagatedBuildInputs`.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
