### PR TITLE
fix: output_path and derivation_path may be null or false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,6 @@
 ## [Unreleased]
 ### Added
 - [#34](https://github.com/tweag/nixtract/pull/34) add option to provide nixtract with a status communication channel
+
+### Fixed
+- [#38](https://github.com/tweag/nixtract/pull/38) fixed bug where found derivations were parsed incorrectly


### PR DESCRIPTION
# output_path and derivation_path may be null or false
<!-- Please refer to an issue, or remove this line if the PR is unrelated to an issue -->
Issue: #37 

## Description
The `FoundDrv` struct incorrectly assumed the `output_path` and `derivation_path` were always String. Unfortunately, this doesn't hold. The values may also be `null` or `false`. Additionally, I've changed the error return into a warning message, simply skipping any found drvs that we cannot parse.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
