### PR TITLE
lib.nix: fix safeEval

### DIFF
--- a/src/nix/lib.nix
+++ b/src/nix/lib.nix
@@ -73,7 +73,12 @@ rec {
 
   /* Utility function for safe evaluation of any value, null if evaluation fails
   */
-  safeEval = v: (builtins.tryEval v).value or null;
+  safeEval = v: let
+    r = builtins.tryEval v;
+  in
+    if r.success
+    then r.value
+    else null;
 
   /* Utility specific to nixpkgs, as nixpkgs prevents computing some fields if meta.platforms does not contain the target system
     Args:


### PR DESCRIPTION
The previous version returned `false` instead of `null` in case of failed evaluation.

I'm actually building a very similar project to yours (not same goal, but similar technical architecture: extracting all `outPath`s from all `nixpkgs`' derivations with `nix eval --json` and parsing the result from rust) and reading your source code helped me greatly!!
I didn't know about the `recurseForDerivations` "magic/undocumented" attribute so I was stuck with infinite recursion and errors uncatchable with `tryEval` ...

Anyway, I wrote a similar function to your `safeEval` and I saw yours was wrong so here's the fix.
