### PR TITLE
fix: log warning when failing to fetch narinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - [#34](https://github.com/tweag/nixtract/pull/34) add option to provide nixtract with a status communication channel
 - [#36](https://github.com/tweag/nixtract/pull/36) add option to only extract runtime dependencies
+- [#40](https://github.com/tweag/nixtract/pull/40) log warning when narinfo fetching fails
 
 ### Fixed
 - [#38](https://github.com/tweag/nixtract/pull/38) fixed bug where found derivations were parsed incorrectly

--- a/src/nix/narinfo.rs
+++ b/src/nix/narinfo.rs
@@ -84,13 +84,17 @@ impl NarInfo {
             );
 
             log::info!("Fetching narinfo from {}", url);
-            if let Ok(response) = reqwest::blocking::get(&url) {
-                if response.status().is_success() {
-                    let narinfo = response.text()?;
-                    return Ok(Some(Self::parse(&narinfo)?));
-                } else {
-                    log::warn!("Cache responded with error code: {}", response.status());
+            match reqwest::blocking::get(&url) {
+                Ok(response) => {
+                    if response.status().is_success() {
+                        let narinfo = response.text()?;
+                        let narinfo = Self::parse(&narinfo)?;
+                        return Ok(Some(narinfo));
+                    } else {
+                        log::warn!("Cache responded with error code: {}", response.status());
+                    }
                 }
+                Err(err) => log::warn!("Could not fetch narinfo: {}", err),
             }
         }
 


### PR DESCRIPTION
# Narinfo Error

## Description
When failing to retrieve the narinfo, now log a warning instead of continuing silently.

This would have saved me a lot of time if we had done this before, I couldn't figure out why my nixtract output didn't contain narinfo, but I was just not connected to the internet...

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
