### PR TITLE
Output source like Python version did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - [#38](https://github.com/tweag/nixtract/pull/38) fixed bug where found derivations were parsed incorrectly
+- [#42](https://github.com/tweag/nixtract/pull/42) reintroduced the src field in the derivation description
 
 ### Changed
 - [#36](https://github.com/tweag/nixtract/pull/36) moved all nixtract configuration options into a single struct passed to the `nixtract` function

--- a/src/nix/describe_derivation.nix
+++ b/src/nix/describe_derivation.nix
@@ -31,6 +31,17 @@ in
   name = targetValue.name;
   parsed_name = (builtins.parseDrvName targetValue.name);
   attribute_path = targetAttributePath;
+
+  src =
+    if targetValue ? src.gitRepoUrl && targetValue ? src.rev
+    then
+      {
+        git_repo_url = targetValue.src.gitRepoUrl;
+        rev = targetValue.src.rev;
+      }
+    else
+      null;
+
   nixpkgs_metadata =
     {
       description = (builtins.tryEval (targetValue.meta.description or "")).value;


### PR DESCRIPTION
<!-- Please refer to an issue, or remove this line if the PR is unrelated to an issue -->
Issue: #32 

## Description
In the grand RIIR, the src field of the derivation descriptions was missed. This PR reintroduces it.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
