### PR TITLE
fix: enable experimental features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - [#38](https://github.com/tweag/nixtract/pull/38) fixed bug where found derivations were parsed incorrectly
 - [#42](https://github.com/tweag/nixtract/pull/42) reintroduced the src field in the derivation description
+- [#43](https://github.com/tweag/nixtract/pull/43) enables the `flakes` and `nix-command` features for nix invocations, this avoids users having to have them enabled manually
 
 ### Changed
 - [#36](https://github.com/tweag/nixtract/pull/36) moved all nixtract configuration options into a single struct passed to the `nixtract` function

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       in
       {
         defaultPackage = naersk-lib.buildPackage {
-          pname = "genealogos";
+          pname = "nixtract";
           src = ./.;
 
           # nixtract uses the reqwest crate to query for narinfo on the substituters.

--- a/src/nix/describe_derivation.rs
+++ b/src/nix/describe_derivation.rs
@@ -126,6 +126,7 @@ pub fn describe_derivation(args: &DescribeDerivationArgs) -> Result<DerivationDe
         .arg(format!("lib={}", args.lib.path().to_string_lossy()))
         .args(["--json", "--expr", expr])
         .arg("--impure")
+        .args(["--extra-experimental-features", "flakes nix-command"])
         .envs(env_vars);
 
     // Add --offline if offline is set

--- a/src/nix/find_attribute_paths.rs
+++ b/src/nix/find_attribute_paths.rs
@@ -57,6 +57,7 @@ pub fn find_attribute_paths(
         .arg(format!("lib={}", lib.path().to_string_lossy()))
         .args(["--json", "--expr", expr])
         .arg("--impure")
+        .args(["--extra-experimental-features", "flakes nix-command"])
         .envs(env_vars);
 
     if *offline {

--- a/src/nix/substituters.rs
+++ b/src/nix/substituters.rs
@@ -14,6 +14,7 @@ fn from_flake_ref(flake_ref: &str) -> Result<Substituters> {
     let output = std::process::Command::new("nix")
         .args(["eval", "--json", "--impure"])
         .args(["--expr", &expr])
+        .args(["--extra-experimental-features", "flakes nix-command"])
         .output()?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -35,6 +36,7 @@ fn from_flake_ref(flake_ref: &str) -> Result<Substituters> {
 fn from_nix_conf() -> Result<Substituters> {
     let output = std::process::Command::new("nix")
         .args(["show-config", "--json"])
+        .args(["--extra-experimental-features", "flakes nix-command"])
         .output()?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Description
This PR adds the `--extra-experimental-features "flakes nix-command"` to the `nix` invocations.

## Motivation
The Genealogos README does mention that `flakes` and `nix-command` must be enabled for it to function, and we could have gone with a similar approach for nixtract. But, since this flag is a no-op on systems where `flakes` and `nix-command` are already enabled anyway, we can set it here and avoid users having to set it manually.

Either way, we are limited to a version of nix that supports these features.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- ~[ ] README.md up-to-date~
