### PR TITLE
Darwin build failure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,14 @@
 
           # nixtract uses the reqwest crate to query for narinfo on the substituters.
           # reqwest depends on openssl.
-          nativeBuildInputs = with pkgs; [ pkg-config ];
-          buildInputs = with pkgs; [ openssl ];
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+          buildInputs = with pkgs; ([
+            openssl
+          ] ++ lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.SystemConfiguration
+          ]);
         };
         devShell = with pkgs; mkShell {
           buildInputs = [
@@ -33,7 +39,10 @@
 
             pkg-config
             openssl
+          ] ++ lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.SystemConfiguration
           ];
+
           RUST_SRC_PATH = rustPlatform.rustLibSrc;
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,10 @@
           ];
           buildInputs = with pkgs; ([
             openssl
-          ] ++ lib.optionals stdenv.isDarwin [
-            darwin.apple_sdk.frameworks.SystemConfiguration
-          ]);
+          ] ++ lib.optionals stdenv.isDarwin (with darwin; [
+            apple_sdk.frameworks.SystemConfiguration
+            libiconv
+          ]));
         };
         devShell = with pkgs; mkShell {
           buildInputs = [
@@ -39,9 +40,10 @@
 
             pkg-config
             openssl
-          ] ++ lib.optionals stdenv.isDarwin [
+          ] ++ lib.optionals stdenv.isDarwin (with darwin; [
             darwin.apple_sdk.frameworks.SystemConfiguration
-          ];
+            libiconv
+          ]);
 
           RUST_SRC_PATH = rustPlatform.rustLibSrc;
         };


### PR DESCRIPTION
<!-- Please refer to an issue, or remove this line if the PR is unrelated to an issue -->
Issue: #45 

## Description
Two packages necessary for a Darwin build were not in our devshell, or even included in the nix build. This PR resolves that issue.

## Motivation
There is no particular reason for us not to support any system on which both Rust and Nix are supported, until we run into some fundamental problems. Therefore, Darwin should be buildable.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
