### PR TITLE
feat: include stdenv and dependencies in outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- We follow the Keep a Changelog standard https://keepachangelog.com/en/1.0.0/ -->
 
 ## [Unreleased]
+### Added
+- [#48](https://github.com/tweag/nixtract/pull/48) adds stdenv to one of the attributes of a package that nixtract explores
 
 ## [0.3.0] - 2024-04-17
 ### Added

--- a/src/nix/describe_derivation.nix
+++ b/src/nix/describe_derivation.nix
@@ -101,8 +101,14 @@ in
           )
       )
       (
-        [ "buildInputs" "propagatedBuildInputs" ]
-        ++ nixpkgs.lib.optionals (!runtimeOnly) [ "nativeBuildInputs" ]
+        [ "buildInputs" "propagatedBuildInputs" "defaultBuildInputs" ]
+          ++ nixpkgs.lib.optionals (!runtimeOnly) [ "nativeBuildInputs" "defaultNativeBuildInputs" ]
       )
-    );
+    ) ++ nixpkgs.lib.optional (targetValue ? stdenv)
+    {
+      build_input_type = "stdenv";
+      attribute_path = targetAttributePath + ".stdenv";
+      output_path = lib.safePlatformDrvEval targetSystem (drv: drv.outPath) targetValue.stdenv;
+    }
+  ;
 }


### PR DESCRIPTION
## Description
This PR adds the stdenv buildInput to the nixtract output.

## Motivation
stdenv contains many implicit buildInputs (e.g. gcc). These were previously not part of the nixtract output. There are more of such missed attributes, but stdenv is undoubtedly the most important one.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
