### PR TITLE
fix: stop recursion already when root attribute is a derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - [#49](https://github.com/tweag/nixtract/pull/49) rewrite describe_derivation to include all found derivations (but actively skip bootstrap packages)
 
+### Fixed
+- [#50](https://github.com/tweag/nixtract/pull/50) fix an issue where the root attribute was never assumed to be a derivation
+
 ## [0.3.0] - 2024-04-17
 ### Added
 - [#34](https://github.com/tweag/nixtract/pull/34) add option to provide nixtract with a status communication channel

--- a/src/nix/find_attribute_paths.nix
+++ b/src/nix/find_attribute_paths.nix
@@ -72,4 +72,4 @@ let
   ;
 in
 # to prevent accumlutation in memory
-lib.collect (x: false) (builtins.mapAttrs (findRecursively targetAttributePath) targetRootValue)
+lib.collect (x: false) (builtins.mapAttrs (findRecursively "") (builtins.listToAttrs [{ name = targetAttributePath; value = targetRootValue; }]))


### PR DESCRIPTION
## Description
This PR ensures the recursion in `find_attribute_paths` doesn't recurse if the root attribute is a derivation itself.

Previously, nixtract would assume the root attribute was a attribute set with derivations in its branches.

## Motivation
This fix resolves issues where the root attribute was a derivation, but not assumed to be. For exmaple, excluded bootstrap packages would still be considered.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
