### PR TITLE
feat: skip fods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - [#49](https://github.com/tweag/nixtract/pull/49) rewrite describe_derivation to include all found derivations (but actively skip bootstrap packages)
 
+### Removed
+- [#50](https://github.com/tweag/nixtract/pull/50) excludes fixed output derivations in nixtract output
+
 ## [0.3.0] - 2024-04-17
 ### Added
 - [#34](https://github.com/tweag/nixtract/pull/34) add option to provide nixtract with a status communication channel

--- a/src/nix/describe_derivation.nix
+++ b/src/nix/describe_derivation.nix
@@ -82,6 +82,7 @@ in
       targetValue;
   outputs = map (name: { inherit name; output_path = lib.safePlatformDrvEval targetSystem (drv: drv.outPath) targetValue.${name}; }) (targetValue.outputs or [ ]);
   build_inputs =
+    if targetValue ? outputHash then [ ] else
     nixpkgs.lib.concatMap
       ({ name, value }:
         if nixpkgs.lib.isDerivation value then


### PR DESCRIPTION
## Description
This PR makes it so that any encountered FOD does not return build inputs.

## Motivation
The exact way of how the FODs are acquired is mostly irrelevant.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
