### PR TITLE
fix: log found derivations in the collected_paths set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Removed
 - [#50](https://github.com/tweag/nixtract/pull/50) excludes fixed output derivations in nixtract output
 
+### Fixed
+- [#53](https://github.com/tweag/nixtract/pull/53) resolve an issue where some derivations were analyzed multiple times
+
 ## [0.3.0] - 2024-04-17
 ### Added
 - [#34](https://github.com/tweag/nixtract/pull/34) add option to provide nixtract with a status communication channel

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,16 @@ pub fn nixtract(
         derivations.extend(attribute_path.found_drvs);
     }
 
+    for found_drv in derivations.clone() {
+        match found_drv.output_path {
+            None => log::warn!("Found a derivation without an output_path: {:?}", found_drv),
+            Some(output_path) => {
+                let mut collected_paths = collected_paths.lock().unwrap();
+                collected_paths.insert(output_path);
+            }
+        }
+    }
+
     // Spawn a new rayon thread to call process on every foundDrv
     rayon::spawn(move || {
         derivations.into_par_iter().for_each(|found_drv| {


### PR DESCRIPTION
## Description
The collected_paths hashSet contains alll the previously collected output paths. Previously, we didn't store the initially found derivations in this set. This PR resolves that.

## Motivation
Genealogos expects the list to be unique by their store path, this PR ensures that is the case.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
